### PR TITLE
ELIMINADO LAS COLMNAS CORRESPONDIENTES DEL REPORTE

### DIFF
--- a/capa_dominio/dto/ReporteNominaDTO.cs
+++ b/capa_dominio/dto/ReporteNominaDTO.cs
@@ -18,7 +18,6 @@ namespace capa_dominio.dto
         public string TipoTrabajador { get; set; }
         public string FechaInicioContrato { get; set; }
         public string FechaFinContrato { get; set; } 
-        public string TipoDeJornadaPactada { get; set; }
         public decimal? HorasSemanalesPactadas { get; set; } 
         public decimal? HorasExtrasReales { get; set; } 
         public decimal SueldoBasico { get; set; }
@@ -29,17 +28,12 @@ namespace capa_dominio.dto
         public decimal TotalHaberesBruto { get; set; }
         public decimal TotalHaberes { get; set; }
         public decimal AporteSistemaPension { get; set; }
-        public decimal DescuentoONP { get; set; }
-        public decimal DescuentoAFP { get; set; }
         public decimal RetencionImpuestoRenta { get; set; }
         public decimal AporteEsSalud { get; set; }
         public decimal BaseImponibleEsSalud { get; set; }
         public decimal DescuentoTardanzas { get; set; }
         public decimal DescuentoFaltas { get; set; }
-        public decimal DescuentoAdelantos { get; set; }
-        public decimal OtrosDescuentos { get; set; }
         public decimal TotalDescuentos { get; set; }
         public decimal NetoPagar { get; set; }
-        public string PeriodoNomina { get; set; }
     }
 }

--- a/capa_persistencia/modulo_principal/ReporteNomina.cs
+++ b/capa_persistencia/modulo_principal/ReporteNomina.cs
@@ -55,7 +55,6 @@ namespace capa_persistencia.modulo_principal
                                                   : Convert.ToDateTime(dr["FechaFinContrato"]).ToString("yyyy-MM-dd"),
 
                             // ===== JORNADA =====
-                            TipoDeJornadaPactada = dr["TipoDeJornadaPactada"].ToString(),
                             HorasSemanalesPactadas = dr["HorasSemanalesPactadas"] == DBNull.Value
                                                      ? null
                                                      : (decimal?)Convert.ToDecimal(dr["HorasSemanalesPactadas"]),
@@ -75,8 +74,6 @@ namespace capa_persistencia.modulo_principal
 
                             // ===== DESCUENTOS =====
                             AporteSistemaPension = Convert.ToDecimal(dr["AporteSistemaPension"]),
-                            DescuentoONP = Convert.ToDecimal(dr["DescuentoONP"]),
-                            DescuentoAFP = Convert.ToDecimal(dr["DescuentoAFP"]),
                             RetencionImpuestoRenta = Convert.ToDecimal(dr["RetencionImpuestoRenta"]),
 
                             // ===== EMPLEADOR =====
@@ -86,15 +83,10 @@ namespace capa_persistencia.modulo_principal
                             // ===== OTROS DESCUENTOS =====
                             DescuentoTardanzas = Convert.ToDecimal(dr["DescuentoTardanzas"]),
                             DescuentoFaltas = Convert.ToDecimal(dr["DescuentoFaltas"]),
-                            DescuentoAdelantos = Convert.ToDecimal(dr["DescuentoAdelantos"]),
-                            OtrosDescuentos = Convert.ToDecimal(dr["OtrosDescuentos"]),
 
                             // ===== TOTALES =====
                             TotalDescuentos = Convert.ToDecimal(dr["TotalDescuentos"]),
                             NetoPagar = Convert.ToDecimal(dr["NetoPagar"]),
-
-                            // ===== CONTEXTO =====
-                            PeriodoNomina = dr["PeriodoNomina"].ToString()
                         };
 
                         lista.Add(dto);

--- a/capa_presentacion/Scripts/reporte/generarReporte.js
+++ b/capa_presentacion/Scripts/reporte/generarReporte.js
@@ -155,7 +155,6 @@
             escapeHtml(item.TipoTrabajador || ''),
             escapeHtml(item.FechaInicioContrato || ''),
             escapeHtml(item.FechaFinContrato || ''),
-            escapeHtml(item.TipoDeJornadaPactada || ''),
             formatearNumero(item.HorasSemanalesPactadas),
             formatearNumero(item.HorasExtrasReales),
             formatearMonedaConSimbolo(item.SueldoBasico),
@@ -166,18 +165,13 @@
             formatearMonedaConSimbolo(item.TotalHaberesBruto),
             formatearMonedaConSimbolo(item.TotalHaberes),
             formatearMonedaConSimbolo(item.AporteSistemaPension),
-            formatearMonedaConSimbolo(item.DescuentoONP),
-            formatearMonedaConSimbolo(item.DescuentoAFP),
             formatearMonedaConSimbolo(item.RetencionImpuestoRenta),
             formatearMonedaConSimbolo(item.AporteEsSalud),
             formatearMonedaConSimbolo(item.BaseImponibleEsSalud),
             formatearMonedaConSimbolo(item.DescuentoTardanzas),
             formatearMonedaConSimbolo(item.DescuentoFaltas),
-            formatearMonedaConSimbolo(item.DescuentoAdelantos),
-            formatearMonedaConSimbolo(item.OtrosDescuentos),
             formatearMonedaConSimbolo(item.TotalDescuentos),
-            `<span class="highlight">${formatearMonedaConSimbolo(item.NetoPagar)}</span>`,
-            escapeHtml(item.PeriodoNomina || '')
+            `<span class="highlight">${formatearMonedaConSimbolo(item.NetoPagar)}</span>`
         ];
 
         return `<tr>${campos.map((campo, i) => crearCelda(campo, i + 1)).join('')}</tr>`;
@@ -282,7 +276,6 @@
             url: urlExportacion
         });
 
-        // Usar el exportador
         ExportadorReportes.exportarPDF({
             url: urlExportacion,
             periodoId: state.periodoSeleccionado,
@@ -332,7 +325,6 @@
             .substring(0, 50);
     }
 
-    // ===== UTILIDADES UI =====
     function mostrarCargando() {
         elements.tableBody.html(crearMensajeEstado('loading', '📊', 'Cargando datos...'));
         actualizarContador(0);
@@ -361,7 +353,6 @@
         elements.recordsCount.text(`${count} ${texto}`);
     }
 
-    // ===== UTILIDADES DE FORMATO =====
     function formatearMoneda(valor) {
         if (valor == null || isNaN(valor)) return '0.00';
         return parseFloat(valor).toFixed(2);
@@ -402,7 +393,6 @@
 
 })();
 
-// Inicializar cuando el documento esté listo
 $(document).ready(() => {
     console.log('📄 DOM Ready');
     ReporteNomina.init();

--- a/capa_presentacion/Views/GenerarReporte/Index.cshtml
+++ b/capa_presentacion/Views/GenerarReporte/Index.cshtml
@@ -55,7 +55,6 @@
                         <th>Tipo Trabajador</th>
                         <th>Fecha Inicio</th>
                         <th>Fecha Fin</th>
-                        <th>Tipo Jornada</th>
                         <th>Hrs Semanales</th>
                         <th>Hrs Extras</th>
                         <th>Sueldo Básico</th>
@@ -66,18 +65,13 @@
                         <th>Total Haberes Bruto</th>
                         <th>Total Haberes</th>
                         <th>Aporte Pensión</th>
-                        <th>Desc. ONP</th>
-                        <th>Desc. AFP</th>
                         <th>Ret. Imp. Renta</th>
                         <th>Aporte EsSalud</th>
                         <th>Base Imp. EsSalud</th>
                         <th>Desc. Tardanzas</th>
                         <th>Desc. Faltas</th>
-                        <th>Desc. Adelantos</th>
-                        <th>Otros Desc.</th>
                         <th>Total Desc.</th>
                         <th>Neto a Pagar</th>
-                        <th>Periodo</th>
                     </tr>
                 </thead>
                 <tbody id="tableBody">
@@ -90,23 +84,18 @@
 
 @section Scripts {
     <script>
-        // Configuración de URLs del servidor
         window.AppConfig = {
             urls: {
                 obtenerCargos: '@Url.Action("ObtenerCargos", "Cargo")',
                 listarPeriodos: '@Url.Action("ListarPeriodos", "GenerarReporte")',
                 listarNomina: '@Url.Action("ListarNominaPorPeriodo", "GenerarReporte")',
-                generarExcel: '@Url.Action("GenerarExcel", "GenerarReporte")',
                 generarPDF: '@Url.Action("GenerarPDF", "GenerarReporte")'
             }
         };
-        console.log('✅ AppConfig cargado:', window.AppConfig);
     </script>
 
-    <!-- jQuery (REQUERIDO - debe cargarse primero) -->
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 
-    <!-- Scripts del proyecto EN ORDEN -->
     <script src="~/Scripts/reporte/reporte.alerta.js"></script>
     <script src="~/Scripts/reporte/exportadorReporte.js"></script>
     <script src="~/Scripts/reporte/generarReporte.js"></script>


### PR DESCRIPTION
- Se quitaron de la tabla las columnas de TIPO DE JORNADA, ONP, AFP, ADELANTOS, OTROS DESC, PERIODO, al igual que se hizo los cambios respectivos para que no se muestren. Modificacion en: DTO, ReporteNomina.cs, generarReporte.js y Index