### PR TITLE
Añadir KPIs de nómina en backend y frontend

### DIFF
--- a/capa_aplicacion/sevicios/NominasServicios.cs
+++ b/capa_aplicacion/sevicios/NominasServicios.cs
@@ -488,5 +488,11 @@ namespace capa_aplicacion.servicios
                 _conexion.CerrarConexion();
             }
         }
+
+        public ResumenKpisNominaDto ObtenerResumenKpisNomina()
+        {
+            // Simplemente delega al repositorio
+            return _nominas.ObtenerResumenKpisNomina();
+        }
     }
 }

--- a/capa_dominio/capa_dominio.csproj
+++ b/capa_dominio/capa_dominio.csproj
@@ -62,6 +62,7 @@
     <Compile Include="dto\ImpuestoRentaAcumuladoDTO.cs" />
     <Compile Include="dto\ResultadoEmpleadosDTO.cs" />
     <Compile Include="dto\ResumenContratosDTO.cs" />
+    <Compile Include="dto\ResumenKpisNominaDTO.cs" />
     <Compile Include="dto\ResumenNominaDTO.cs" />
     <Compile Include="dto\TrabajadorProcesableDTO.cs" />
     <Compile Include="EstadoContrato.cs" />

--- a/capa_dominio/dto/ResumenKpisNominaDTO.cs
+++ b/capa_dominio/dto/ResumenKpisNominaDTO.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace capa_dominio.dto
+{
+    public class ResumenKpisNominaDto
+    {
+        public int TotalPeriodosAbiertos { get; set; }
+        public int TotalPeriodosProcesados { get; set; }
+        public int TotalTrabajadoresInactivos { get; set; }
+        public decimal TotalNetoGeneral { get; set; }
+    }
+}

--- a/capa_persistencia/modulo_principal/NominasRepositorio.cs
+++ b/capa_persistencia/modulo_principal/NominasRepositorio.cs
@@ -181,6 +181,40 @@ namespace capa_persistencia.modulo_principal
 
             return lista;
         }
+        public ResumenKpisNominaDto ObtenerResumenKpisNomina()
+        {
+            _accesoSQL.AbrirConexion(); 
+
+            try
+            {
+                var resumen = new ResumenKpisNominaDto();
+                var comando = _accesoSQL.ObtenerComandoDeProcedimiento("nomina.proc_resumen_kpis_nomina");
+
+                using (var reader = comando.ExecuteReader())
+                {
+                    if (reader.Read())
+                    {
+                        resumen.TotalPeriodosAbiertos = reader.IsDBNull(reader.GetOrdinal("total_periodos_abiertos"))
+                            ? 0 : reader.GetInt32(reader.GetOrdinal("total_periodos_abiertos"));
+
+                        resumen.TotalPeriodosProcesados = reader.IsDBNull(reader.GetOrdinal("total_periodos_procesados"))
+                            ? 0 : reader.GetInt32(reader.GetOrdinal("total_periodos_procesados"));
+
+                        resumen.TotalTrabajadoresInactivos = reader.IsDBNull(reader.GetOrdinal("total_trabajadores_inactivos"))
+                            ? 0 : reader.GetInt32(reader.GetOrdinal("total_trabajadores_inactivos"));
+
+                        resumen.TotalNetoGeneral = reader.IsDBNull(reader.GetOrdinal("total_neto_general"))
+                            ? 0 : reader.GetDecimal(reader.GetOrdinal("total_neto_general"));
+                    }
+                }
+
+                return resumen;
+            }
+            finally
+            {
+                _accesoSQL.CerrarConexion(); // ← CERRAR SIEMPRE
+            }
+        }
 
 
     }

--- a/capa_presentacion/Content/css/listavigente.css
+++ b/capa_presentacion/Content/css/listavigente.css
@@ -303,7 +303,6 @@ input[type="text"]#txtBuscarEmpleado {
 }
 
     .kpi-value.money::before {
-        content: 'S/ ';
         font-size: 18px;
         color: #666;
     }

--- a/capa_presentacion/Controllers/NominaController.cs
+++ b/capa_presentacion/Controllers/NominaController.cs
@@ -235,4 +235,34 @@ public class NominaController : Controller
             return Json(new { data = (object)null, consultaExitosa = false, mensaje = ex.Message }, JsonRequestBehavior.AllowGet);
         }
     }
+    [HttpGet]
+public JsonResult ObtenerKpisNomina()
+{
+    try
+    {
+        var resumen = _servicio.ObtenerResumenKpisNomina();
+
+        return Json(new
+        {
+            exito = true,
+            kpis = new
+            {
+                totalPeriodosAbiertos = resumen.TotalPeriodosAbiertos,
+                totalPeriodosProcesados = resumen.TotalPeriodosProcesados,
+                totalTrabajadoresInactivos = resumen.TotalTrabajadoresInactivos,
+                totalNetoGeneral = resumen.TotalNetoGeneral
+            }
+        }, JsonRequestBehavior.AllowGet);
+    }
+        catch (Exception ex)
+        {
+            return Json(new
+            {
+                exito = false,
+                mensaje = ex.ToString()
+            }, JsonRequestBehavior.AllowGet);
+        }
+
+    }
+
 }

--- a/capa_presentacion/Scripts/nomina/nomina.kpis.js
+++ b/capa_presentacion/Scripts/nomina/nomina.kpis.js
@@ -17,7 +17,7 @@
             elements.kpiPendientes.text('0');
             elements.kpiProcesadas.text('0');
             elements.kpiInactivos.text('0');
-            elements.kpiTotalNomina.text('S/ 0.00');
+            elements.kpiTotalNomina.text('0.00');
             return;
         }
 
@@ -31,9 +31,22 @@
         elements.kpiTotalNomina.text('S/ ' + formatearMoneda(totalNeto));
     }
 
+    // ✅ NUEVO: KPIs que vienen del backend
+    function desdeResumen(kpis, elements, formatearMoneda) {
+        if (!elements || !kpis) return;
+
+        elements.kpiPendientes.text(kpis.totalPeriodosAbiertos || 0);
+        elements.kpiProcesadas.text(kpis.totalPeriodosProcesados || 0);
+        elements.kpiInactivos.text(kpis.totalTrabajadoresInactivos || 0);
+
+        const totalNeto = kpis.totalNetoGeneral || 0;
+        elements.kpiTotalNomina.text('S/ ' + formatearMoneda(totalNeto));
+    }
+
     global.NominaKPIs = {
         init,
-        desdeEmpleados
+        desdeEmpleados,
+        desdeResumen // 👈 IMPORTANTE: ahora también exportamos esta
     };
 
     console.log('✅ nomina.kpis.js cargado');

--- a/capa_presentacion/Scripts/nomina/nomina.service.js
+++ b/capa_presentacion/Scripts/nomina/nomina.service.js
@@ -70,6 +70,14 @@
                 dataType: 'json',
                 data: { periodoId: periodoId }
             });
+        },
+
+        obtenerKpisNomina: function () {
+            return $.ajax({
+                url: global.NominaConfig.urls.obtenerKpisNomina,
+                type: 'GET',
+                dataType: 'json'
+            });
         }
     };
 

--- a/capa_presentacion/Scripts/nomina/nomina.ui.js
+++ b/capa_presentacion/Scripts/nomina/nomina.ui.js
@@ -118,9 +118,25 @@ const NominaUI = (function () {
     // ===== DATOS =====
     function cargarDatosIniciales() {
         NominaService.listarPeriodos()
-            .done(r => { if (r.consultaExitosa) renderizarSelectPeriodos(r.data); });
+            .done(r => {
+                if (r.consultaExitosa) renderizarSelectPeriodos(r.data);
+            });
+
         NominaKPIs.init(elements);
+
+        NominaService.obtenerKpisNomina()
+            .done(function (response) {
+                if (!response || !response.exito) {
+                    console.warn('No se pudo obtener KPIs de nómina');
+                    return;
+                }
+                NominaKPIs.desdeResumen(response.kpis, elements, formatearMoneda);
+            })
+            .fail(function (xhr, status, error) {
+                console.error('Error al obtener KPIs de nómina:', error);
+            });
     }
+
 
     function cargarEmpleadosVigentes() {
         if (!periodoSeleccionado) return limpiarTablaVigentes();

--- a/capa_presentacion/Scripts/nomina/nomina.ui.js
+++ b/capa_presentacion/Scripts/nomina/nomina.ui.js
@@ -119,23 +119,27 @@ const NominaUI = (function () {
     function cargarDatosIniciales() {
         NominaService.listarPeriodos()
             .done(r => {
-                if (r.consultaExitosa) renderizarSelectPeriodos(r.data);
+                if (r?.consultaExitosa) {
+                    renderizarSelectPeriodos(r.data);
+                }
             });
 
         NominaKPIs.init(elements);
 
         NominaService.obtenerKpisNomina()
             .done(function (response) {
-                if (!response || !response.exito) {
+           
+                if (!response?.exito) {
                     console.warn('No se pudo obtener KPIs de nómina');
                     return;
                 }
-                NominaKPIs.desdeResumen(response.kpis, elements, formatearMoneda);
+                NominaKPIs.desdeResumen(response.kpis || {}, elements, formatearMoneda);
             })
             .fail(function (xhr, status, error) {
                 console.error('Error al obtener KPIs de nómina:', error);
             });
     }
+
 
 
     function cargarEmpleadosVigentes() {

--- a/capa_presentacion/Views/Nomina/Index.cshtml
+++ b/capa_presentacion/Views/Nomina/Index.cshtml
@@ -42,7 +42,8 @@
                 procesarTrabajador: '@Url.Action("ProcesarTrabajador", "Nomina")',
                 cerrarProceso: '@Url.Action("CerrarProceso", "Nomina")',
                 obtenerEmpleadosVigentesPorPeriodo: '@Url.Action("ObtenerEmpleadosVigentesPorPeriodo", "Nomina")',
-                obtenerResumenProcesoNomina: '@Url.Action("ObtenerResumenProcesoNomina", "Nomina")'
+                obtenerResumenProcesoNomina: '@Url.Action("ObtenerResumenProcesoNomina", "Nomina")',
+                obtenerKpisNomina: '@Url.Action("ObtenerKpisNomina", "Nomina")'
             }
         };
     </script>


### PR DESCRIPTION
Se implementó la funcionalidad para mostrar KPIs de nómina:
- Se agregó el método `ObtenerResumenKpisNomina` en servicios y repositorio.
- Se creó el DTO `ResumenKpisNominaDto` para manejar los datos.
- Se añadió un nuevo endpoint en `NominaController` para exponer los KPIs.
- Se actualizaron los archivos JS (`nomina.kpis.js`, `nomina.service.js`, `nomina.ui.js`) para consumir y mostrar los KPIs.
- Se eliminó el prefijo `'S/ '` en el diseño y en las funciones relacionadas.
- Se incluyó la URL del nuevo endpoint en `Index.cshtml`.