### PR TITLE
Simplificar manejo de TipoJornadaId y HorasSemanales

### DIFF
--- a/capa_dominio/dto/ContratoDTO.cs
+++ b/capa_dominio/dto/ContratoDTO.cs
@@ -11,6 +11,7 @@ namespace capa_dominio.dto
         private int? areaId;
         private int? tipoPensionId;
         private int? tipoSalarioId;
+        private int? tipoJornadaId;
 
 
         private DateTime fechaInicio;
@@ -30,6 +31,8 @@ namespace capa_dominio.dto
         public int? AreaId { get => areaId; set => areaId = value; }
         public int? TipoPensionId { get => tipoPensionId; set => tipoPensionId = value; }
         public int? TipoSalarioId { get => tipoSalarioId; set => tipoSalarioId = value; }
+
+        public int? TipoJornadaId { get => tipoJornadaId; set => tipoJornadaId = value; }
         public DateTime FechaInicio { get => fechaInicio; set => fechaInicio = value; }
         public DateTime? FechaFin { get => fechaFin; set => fechaFin = value; }
         public decimal? Salario { get => salario; set => salario = value; }

--- a/capa_presentacion/Content/css/parametros.css
+++ b/capa_presentacion/Content/css/parametros.css
@@ -1,124 +1,85 @@
-﻿.modal-parametros {
-    position: fixed;
-    inset: 0;
-    display: none; /* oculto por defecto */
-    align-items: center;
-    justify-content: center;
-    z-index: 999;
-    background-color: #F9FAFB;
-}
-    .modal-parametros.is-open {
-        display: flex; /* se muestra cuando agregamos la clase */
-    }
-    .modal-parametros .modal-backdrop {
-        position: absolute;
-        inset: 0;
-        background: rgba(0,0,0,.45);
-    }
-    .modal-parametros .modal-content {
-        position: relative;
-        z-index: 1;
-        max-width: 960px;
-        max-height: 90vh;
-        overflow: auto;
-        background-color: #FFFFFF;
-        border-radius: 10px;
-        padding: 20px 24px;
-        box-shadow: 0 25px 50px rgba(15,23,42,.35);
-    }
-.modal-header {
-    display: flex;
-    justify-content: space-between;
-    border-bottom: 1px solid #e9ecef;
-    padding-bottom: 10px;
+﻿.parametros-wrapper {
+    padding: 20px 30px;
+    background: #fff;
+    font-family: system-ui, sans-serif;
 }
 
-#tituloPeriodo {
-    margin: 10px 0px;
-    font-size: 18px;
-    font-weight: 700;
-    color: #111827;
-    letter-spacing: .3px;
-    text-transform: uppercase;
-}
-
-.modal-header .close {
-    border: 0;
-    background: transparent;
+.titulo-seccion {
     font-size: 20px;
-    line-height: 1;
-    color: #6B7280;
-    cursor: pointer;
+    font-weight: 700;
+    margin-bottom: 25px;
+    color: #111827;
 }
 
-.modal-content {
-    display: flex;
-    flex-direction: column;
-    background-color: #FFFFFF;
-    justify-content: center;
-    border-radius: 10px;
-    padding: 20px;
-}
-
-.modal-body {
-    display: flex;
+/* GRID DE DOS COLUMNAS */
+.parametros-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
     gap: 30px;
 }
 
-.modal-content h3 {
+/* FILA: etiqueta – info – valor */
+.kv-row {
+    display: grid;
+    grid-template-columns: 2fr 3fr 1fr;
+    column-gap: 16px;
+    padding: 10px 0;
+    border-bottom: 1px solid #E5E7EB;
+}
+
+    .kv-row dt {
+        font-weight: 600;
+        color: #1D4ED8;
+        font-size: 14px;
+    }
+
+    .kv-row dd {
+        margin: 0;
+        font-size: 14px;
+        color: #4B5563;
+    }
+
+.kv-value {
+    text-align: right;
+    font-weight: 600;
+    color: #111827;
+}
+
+/* SUBTÍTULOS */
+.subtitulo {
     color: #2563EB;
     font-size: 15px;
+    margin: 18px 0 6px 0;
+    font-weight: 600;
 }
 
-.modal-body dt, dd {
-    font-size: 14px;
-}
-
-.kv-row {
-    display: flex;
-    justify-content: space-between;
-    gap: 100px;
-    border-bottom: 1px solid #e9ecef;
-    padding-bottom: 10px;
-}
-
-.kv-list {
-    display: flex;
-    flex-direction: column;
-    gap: 20px;
-}
-/* --- TABLA COTIZACIÓN PREVISIONAL --- */
-.tabla-previsional {
+/* TABLAS */
+.tabla-parametros {
+    width: 100%;
     border-collapse: collapse;
-    margin-top: 10px;
-    font-size: 0.95rem;
+    font-size: 14px;
     border-radius: 8px;
     overflow: hidden;
-    width: 100%;
-    font-size: 14px;
+    margin-top: 8px;
 }
 
-    .tabla-previsional thead th {
-        text-align: left;
+    .tabla-parametros th {
+        background: #F9FAFB;
         padding: 10px 12px;
         font-weight: 600;
-        background-color: #f8f9fc;
+        border-bottom: 1px solid #E5E7EB;
+        text-align: left;
     }
 
-    .tabla-previsional tbody td {
-        padding: 9px 12px;
-        border-bottom: 1px solid #e5e7eb;
+    .tabla-parametros td {
+        padding: 10px 12px;
+        border-bottom: 1px solid #E5E7EB;
     }
 
-    .tabla-previsional tbody tr:nth-child(even) {
-        background-color: #f8f9fc;
+    .tabla-parametros tr:nth-child(even) {
+        background: #F9FAFB;
     }
 
-    .tabla-previsional tbody tr:hover {
-        background-color: #E5E7EB;
-        transition: background-color 0.2s ease-in-out;
+    .tabla-parametros tr:hover {
+        background: #E5E7EB;
     }
-
-.modal-body-full {
-    width: 100%;
-}

--- a/capa_presentacion/Controllers/ContratosController.cs
+++ b/capa_presentacion/Controllers/ContratosController.cs
@@ -63,7 +63,7 @@ namespace capa_presentacion.Controllers
 
                     // Para modal
                     CargoId = x.CargoId,
-                    TipoSalarioId = x.TipoSalarioId,
+                    TipoSalarioId = 1,
                     Salario = x.Salario,
                     ModoPago = x.ModoPagoId,
                     Observaciones = x.Observaciones,
@@ -166,19 +166,19 @@ namespace capa_presentacion.Controllers
         //}
 
         // ✅ Obtener tipos de jornadas
-        [HttpGet]
-        public JsonResult ObtenerTiposJornadas()
-        {
-            var tipos = _jornadaService.ObtenerTiposJornadas()
-                .Select(j => new
-                {
-                    id = j.TipoJornadaId,
-                    nombre = j.TipoJornadaNombre
-                })
-                .ToList();
+        //[HttpGet]
+        //public JsonResult ObtenerTiposJornadas()
+        //{
+        //    var tipos = _jornadaService.ObtenerTiposJornadas()
+        //        .Select(j => new
+        //        {
+        //            id = j.TipoJornadaId,
+        //            nombre = j.TipoJornadaNombre
+        //        })
+        //        .ToList();
 
-            return Json(tipos, JsonRequestBehavior.AllowGet);
-        }
+        //    return Json(tipos, JsonRequestBehavior.AllowGet);
+        //}
 
         // ✅ CRear Contrato
         [HttpPost]
@@ -187,6 +187,7 @@ namespace capa_presentacion.Controllers
             try
             {
                 contrato.TipoSalarioId = 1;
+                contrato.TipoJornadaId = 1;
 
                 var nuevoId = servicio.CrearContrato(contrato);
 
@@ -240,6 +241,9 @@ namespace capa_presentacion.Controllers
 
             try
             {
+                contrato.TipoSalarioId = 1;
+                contrato.TipoJornadaId = 1;
+
                 var usuario = User?.Identity != null && User.Identity.IsAuthenticated
                     ? User.Identity.Name
                     : Environment.UserName;

--- a/capa_presentacion/Controllers/MenuController.cs
+++ b/capa_presentacion/Controllers/MenuController.cs
@@ -46,8 +46,8 @@ namespace capa_presentacion.Controllers
                 {
                     Titulo = "Parámetros",
                     Icono = "~/Content/img/icons/Parametros.svg",
-                    Controlador = "Nomina",
-                    Accion = "Parametros"
+                    Controlador = "Parametros",
+                    Accion = "Index"
                 }     
                 
             };

--- a/capa_presentacion/Controllers/ParametrosController .cs
+++ b/capa_presentacion/Controllers/ParametrosController .cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Web.Mvc;
+
+namespace capa_presentacion.Controllers
+{
+    public class ParametrosController : Controller
+    {
+        public ActionResult Index()
+        {
+            return View();
+        }
+    }
+}

--- a/capa_presentacion/Scripts/contrato/contratos.catalogs.js
+++ b/capa_presentacion/Scripts/contrato/contratos.catalogs.js
@@ -156,8 +156,8 @@
             this.cargarAreas();
             this.cargarCargos();
             this.cargarPensiones();
-            this.cargarTiposSalarios();
-            this.cargarJornadas();
+            //this.cargarTiposSalarios();
+            //this.cargarJornadas();
         },
 
         /**
@@ -168,7 +168,7 @@
             this.cargarPensiones('#ec_tipo_pension_id', item.TipoPensionId);
             this.cargarCargos('#ec_cargo_id', item.CargoId);
             /*this.cargarTiposSalarios('#ec_tipo_salario_id', item.TipoSalarioId);*/
-            this.cargarJornadas('#ec_tipo_jornada_id', item.TipoJornadaId);
+            //this.cargarJornadas('#ec_tipo_jornada_id', item.TipoJornadaId);
         }
 
     };

--- a/capa_presentacion/Scripts/contrato/contratos.form.js
+++ b/capa_presentacion/Scripts/contrato/contratos.form.js
@@ -52,7 +52,7 @@
             $('#ec_salario').val(item.Salario || '');
             $('#ec_modo_pago').val('Depósito');
             $('#ec_modo_pago_id').val('1');
-            $('#ec_horas_semanales').val(item.HorasSemanales || '');
+            $('#ec_horas_semanales').val(item.HorasSemanales || 48).prop('readonly', true);
             $('#ec_fecha_inicio').val(item.FechaInicio || '');
             $('#ec_fecha_fin').val(item.FechaFin || '');
             $('#ec_tarifa_hora').val(item.TarifaHora || '');
@@ -73,8 +73,8 @@
             $('#nc_cargo_id').val('');
             $('#nc_area_id').val('');
             $('#nc_tipo_pension_id').val('');
-            $('#nc_tipo_salario_id').val('');
-            $('#nc_tipo_jornada_id').val('');
+            //$('#nc_tipo_salario_id').val('');
+            //$('#nc_tipo_jornada_id').val('');
             $('#nc_modo_pago').val('Depósito');
             $('#nc_modo_pago_id').val('1');
             $('#nc_fecha_inicio').val('');
@@ -97,7 +97,7 @@
                 AreaId: $('#nc_area_id').val() ? Number($('#nc_area_id').val()) : null,
                 TipoPensionId: $('#nc_tipo_pension_id').val() ? Number($('#nc_tipo_pension_id').val()) : null,
                 TipoSalarioId: 1,
-                TipoJornadaId: $('#nc_tipo_jornada_id').val() ? Number($('#nc_tipo_jornada_id').val()) : null,
+                TipoJornadaId: 1,
                 FechaInicio: $('#nc_fecha_inicio').val(),
                 FechaFin: $('#nc_fecha_fin').val() || null,
                 Salario: $('#nc_remuneracion').val() ? parseFloat($('#nc_remuneracion').val()) : null,
@@ -121,7 +121,7 @@
                 AreaId: $('#ec_area_id').val() ? Number($('#ec_area_id').val()) : null,
                 TipoPensionId: $('#ec_tipo_pension_id').val() ? Number($('#ec_tipo_pension_id').val()) : null,
                 TipoSalarioId: 1,
-                TipoJornadaId: $('#ec_tipo_jornada_id').val() ? Number($('#ec_tipo_jornada_id').val()) : null,
+                TipoJornadaId: 1,
                 FechaInicio: $('#ec_fecha_inicio').val(),
                 FechaFin: $('#ec_fecha_fin').val() || null,
                 HorasSemanales: $('#ec_horas_semanales').val() ? parseInt($('#ec_horas_semanales').val(), 10) : null,

--- a/capa_presentacion/Scripts/contrato/contratos.validation.js
+++ b/capa_presentacion/Scripts/contrato/contratos.validation.js
@@ -44,7 +44,7 @@
 
             // Validar TipoJornadaId
             if (!contrato.TipoJornadaId) {
-                return { valido: false, mensaje: 'Seleccione el tipo de jornada.' };
+                contrato.TipoJornadaId = 1;
             }
 
             // Validar Salario (> 0)
@@ -87,11 +87,6 @@
             // Validar Salario (> 0)
             if (data.Salario == null || isNaN(data.Salario) || data.Salario <= 0) {
                 return { valido: false, mensaje: 'Ingrese un salario mayor a 0.' };
-            }
-
-            // Validar HorasSemanales (> 0)
-            if (data.HorasSemanales == null || isNaN(data.HorasSemanales) || data.HorasSemanales <= 0) {
-                return { valido: false, mensaje: 'Ingrese las horas semanales (mayores a 0).' };
             }
 
             // Validar fechas

--- a/capa_presentacion/Views/Contratos/_ModalEditarContrato.cshtml
+++ b/capa_presentacion/Views/Contratos/_ModalEditarContrato.cshtml
@@ -68,21 +68,6 @@
                     </div>
                 </div>
 
-                <!-- Tipo jornada y horas semanales -->
-                <div class="form-row">
-                    <div class="form-field">
-                        <label for="ec_tipo_jornada_id">Tipo de jornada</label>
-                        <select id="ec_tipo_jornada_id" name="TipoJornadaId">
-                            <option value="">Seleccione jornada</option>
-                        </select>
-                    </div>
-
-                    <div class="form-field">
-                        <label for="ec_horas_semanales">Horas semanales</label>
-                        <input id="ec_horas_semanales" name="HorasSemanales" type="number" min="0" />
-                    </div>
-                </div>
-
                 <!-- Fechas -->
                 <div class="form-row">
                     <div class="form-field">
@@ -93,27 +78,6 @@
                     <div class="form-field">
                         <label for="ec_fecha_fin">Fecha de fin</label>
                         <input id="ec_fecha_fin" name="FechaFin" type="date" />
-                    </div>
-                </div>
-
-                <!-- Tarifa hora y modo de pago -->
-                <div class="form-row">
-                    <div class="form-field">
-                        <label for="ec_tarifa_hora">Tarifa por hora</label>
-                        <input id="ec_tarifa_hora"
-                               name="TarifaHora"
-                               type="number"
-                               step="0.01"
-                               min="0"
-                               readonly
-                               class="input-readonly" />
-                    </div>
-
-
-                    <div class="form-field">
-                        <label for="ec_modo_pago">Modo de pago</label>
-                        <input id="ec_modo_pago" name="ModoPago" type="text"
-                               placeholder="Ej: Transferencia, Efectivo, Yape..." />
                     </div>
                 </div>
 

--- a/capa_presentacion/Views/Contratos/_ModalNuevoContrato.cshtml
+++ b/capa_presentacion/Views/Contratos/_ModalNuevoContrato.cshtml
@@ -69,13 +69,13 @@
                         <!--</select>
                     </div>-->
 
-                    <div class="form-field">
+                    <!--<div class="form-field">
                         <label for="nc_tipo_jornada_id">Jornada</label>
                         <select id="nc_tipo_jornada_id" name="TipoJornadaId">
-                            <option value="">Seleccione</option>
+                            <option value="">Seleccione</option>-->
                             @* Tiempo completo / Medio tiempo / etc. *@
-                        </select>
-                    </div>
+                        <!--</select>
+                    </div>-->
 
                     <div class="form-field">
                         <label for="nc_modo_pago">Modo de pago</label>
@@ -113,7 +113,7 @@
                     <div class="form-field">
                         <label for="nc_horas_semanales">Horas semanales</label>
                         <input id="nc_horas_semanales" name="HorasSemanales"
-                               type="number" step="1" min="1" max="60" placeholder="48" />
+                               type="number" value="48" readonly />
                     </div>
 
                     <div class="form-field">

--- a/capa_presentacion/Views/Nomina/_Kpis.cshtml
+++ b/capa_presentacion/Views/Nomina/_Kpis.cshtml
@@ -2,7 +2,7 @@
 <section class="kpis">
     <article class="kpi-card">
         <div class="kpi-meta">
-            <div class="kpi-label">Nóminas Pendientes</div>
+            <div class="kpi-label">Nóminas Abiertas</div>
             <div class="kpi-value" id="kpiPendientes">—</div>
         </div>
         <div class="kpi-icon kpi-warn">

--- a/capa_presentacion/Views/Parametros/Index.cshtml
+++ b/capa_presentacion/Views/Parametros/Index.cshtml
@@ -1,0 +1,124 @@
+﻿@{
+    ViewBag.Title = "Parámetros";
+    ViewBag.PageTitle = "Valores vigentes para el cálculo del período actual";
+    ViewBag.PageSubtitle = "Gestión de nómina - " +
+        DateTime.Now.ToString("MMMM yyyy", new System.Globalization.CultureInfo("es-PE"));
+    ViewBag.PagePeriodo = DateTime.Now.ToString("MMMM yyyy", new System.Globalization.CultureInfo("es-PE"));
+}
+
+@section Head {
+    <link rel="stylesheet" href="~/Content/css/parametros.css?v=@DateTime.Now.Ticks" />
+}
+
+<div class="parametros-wrapper">
+
+    <h2 class="titulo-seccion">SEPTIEMBRE 2025</h2>
+
+    <div class="parametros-grid">
+
+        <!-- COLUMNA 1 -->
+        <div class="columna">
+            <div class="kv-row">
+                <dt>Sueldo Mínimo</dt>
+                <dd>al 01 Septiembre</dd>
+                <dd class="kv-value">S/ 1025.00</dd>
+            </div>
+
+            <div class="kv-row">
+                <dt>UIT</dt>
+                <dd>al 01 Septiembre</dd>
+                <dd class="kv-value">S/ 5350.00</dd>
+            </div>
+
+            <div class="kv-row">
+                <dt>Asignación Familiar</dt>
+                <dd>De la Remuneración Mínima Vital</dd>
+                <dd class="kv-value">10%</dd>
+            </div>
+
+            <div class="kv-row">
+                <dt>Deducción anual</dt>
+                <dd>7 UIT</dd>
+                <dd class="kv-value">S/ 37,450.00</dd>
+            </div>
+        </div>
+
+        <!-- COLUMNA 2 -->
+        <div class="columna">
+
+            <div class="kv-row">
+                <dt>EPS/EsSalud</dt>
+                <dd>EsSalud</dd>
+                <dd class="kv-value">9.0%</dd>
+            </div>
+
+            <div class="kv-row">
+                <dt></dt>
+                <dd>EsSalud aplicable si EPS</dd>
+                <dd class="kv-value">6.75%</dd>
+            </div>
+
+            <div class="kv-row">
+                <dt></dt>
+                <dd>Vigente desde</dd>
+                <dd class="kv-value">1/06/2025</dd>
+            </div>
+
+            <div class="kv-row">
+                <dt>Tasas AFP/ONP</dt>
+                <dd>AFP</dd>
+                <dd class="kv-value">10.0%</dd>
+            </div>
+
+            <div class="kv-row">
+                <dt></dt>
+                <dd>ONP</dd>
+                <dd class="kv-value">13.0% (sin tope)</dd>
+            </div>
+
+            <h3 class="subtitulo">Cotización Previsional</h3>
+            <table class="tabla-parametros">
+                <thead>
+                    <tr>
+                        <th>AFP</th>
+                        <th>Comisión (Flujo)</th>
+                        <th>Comisión (Saldo)</th>
+                        <th>Seguro</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr><td>Habitat</td><td>1.47%</td><td>0.00%</td><td>1.84%</td></tr>
+                    <tr><td>Integra</td><td>1.55%</td><td>0.00%</td><td>1.84%</td></tr>
+                    <tr><td>Prima</td><td>1.60%</td><td>0.00%</td><td>1.84%</td></tr>
+                    <tr><td>ProFuturo</td><td>1.69%</td><td>0.00%</td><td>1.84%</td></tr>
+                </tbody>
+            </table>
+        </div>
+
+    </div>
+
+    <!-- TABLA GRANDE ABAJO -->
+    <h3 class="subtitulo" style="margin-top: 26px;">Tasas de Impuesto Categoría</h3>
+    <table class="tabla-parametros">
+        <thead>
+            <tr>
+                <th>Tramo</th>
+                <th>Límite Bajo (UIT)</th>
+                <th>Límite Alto (UIT)</th>
+                <th>Límite Inferior (S/.)</th>
+                <th>Límite Superior (S/.)</th>
+                <th>Tasa</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr><td>0</td><td>Deducción fija</td><td>7 UIT</td><td>S/ 0.00</td><td>S/ 37,450.00</td><td></td></tr>
+            <tr><td>1</td><td>0</td><td>5 UIT</td><td>S/ 0.00</td><td>S/ 26,750.01</td><td>8%</td></tr>
+            <tr><td>2</td><td>> 5 UIT</td><td>20 UIT</td><td>S/ 26,750.01</td><td>S/ 107,000.00</td><td>14%</td></tr>
+            <tr><td>3</td><td>> 20 UIT</td><td>35 UIT</td><td>S/ 107,000.01</td><td>S/ 187,250.00</td><td>17%</td></tr>
+            <tr><td>4</td><td>> 35 UIT</td><td>45 UIT</td><td>S/ 187,250.01</td><td>S/ 240,750.00</td><td>20%</td></tr>
+            <tr><td>5</td><td>> 45 UIT</td><td>En adelante</td><td>S/ 240,750.01</td><td>—</td><td>30%</td></tr>
+        </tbody>
+    </table>
+
+</div>
+

--- a/capa_presentacion/Views/Parametros/Index.cshtml
+++ b/capa_presentacion/Views/Parametros/Index.cshtml
@@ -9,71 +9,69 @@
 @section Head {
     <link rel="stylesheet" href="~/Content/css/parametros.css?v=@DateTime.Now.Ticks" />
 }
-
 <div class="parametros-wrapper">
 
-    <h2 class="titulo-seccion">SEPTIEMBRE 2025</h2>
+    <h2 class="titulo-seccion">@ViewBag.PagePeriodo.ToString().ToUpper()</h2>
 
     <div class="parametros-grid">
 
         <!-- COLUMNA 1 -->
         <div class="columna">
             <div class="kv-row">
-                <dt>Sueldo Mínimo</dt>
-                <dd>al 01 Septiembre</dd>
-                <dd class="kv-value">S/ 1025.00</dd>
+                <div class="kv-label">Sueldo Mínimo</div>
+                <div class="kv-desc">al 01 Septiembre</div>
+                <div class="kv-value">S/ 1025.00</div>
             </div>
 
             <div class="kv-row">
-                <dt>UIT</dt>
-                <dd>al 01 Septiembre</dd>
-                <dd class="kv-value">S/ 5350.00</dd>
+                <div class="kv-label">UIT</div>
+                <div class="kv-desc">al 01 Septiembre</div>
+                <div class="kv-value">S/ 5350.00</div>
             </div>
 
             <div class="kv-row">
-                <dt>Asignación Familiar</dt>
-                <dd>De la Remuneración Mínima Vital</dd>
-                <dd class="kv-value">10%</dd>
+                <div class="kv-label">Asignación Familiar</div>
+                <div class="kv-desc">De la Remuneración Mínima Vital</div>
+                <div class="kv-value">10%</div>
             </div>
 
             <div class="kv-row">
-                <dt>Deducción anual</dt>
-                <dd>7 UIT</dd>
-                <dd class="kv-value">S/ 37,450.00</dd>
+                <div class="kv-label">Deducción anual</div>
+                <div class="kv-desc">7 UIT</div>
+                <div class="kv-value">S/ 37,450.00</div>
             </div>
         </div>
 
         <!-- COLUMNA 2 -->
         <div class="columna">
-
             <div class="kv-row">
-                <dt>EPS/EsSalud</dt>
-                <dd>EsSalud</dd>
-                <dd class="kv-value">9.0%</dd>
+                <div class="kv-label">EPS/EsSalud</div>
+                <div class="kv-desc">EsSalud</div>
+                <div class="kv-value">9.0%</div>
             </div>
 
             <div class="kv-row">
-                <dt></dt>
-                <dd>EsSalud aplicable si EPS</dd>
-                <dd class="kv-value">6.75%</dd>
+                <div class="kv-label"></div>
+                <div class="kv-desc">EsSalud aplicable si EPS</div>
+                <div class="kv-value">6.75%</div>
             </div>
 
             <div class="kv-row">
-                <dt></dt>
-                <dd>Vigente desde</dd>
-                <dd class="kv-value">1/06/2025</dd>
+                <div class="kv-label"></div>
+                <div class="kv-desc">Vigente desde</div>
+                <div class="kv-value">1/06/2025</div>
             </div>
 
             <div class="kv-row">
-                <dt>Tasas AFP/ONP</dt>
-                <dd>AFP</dd>
-                <dd class="kv-value">10.0%</dd>
+                <div class="kv-label">Tasas AFP/ONP</div>
+                <div class="kv-desc">AFP</div>
+                <div class="kv-value">10.0%</div>
             </div>
 
             <div class="kv-row">
-                <dt></dt>
-                <dd>ONP</dd>
-                <dd class="kv-value">13.0% (sin tope)</dd>
+                <div class="kv-label"></div>
+                <div class="kv-desc">ONP</div>
+                <div class="kv-value">13.0% (sin tope)</div>
             </div>
 
             <h3 class="subtitulo">Cotización Previsional</h3>
@@ -98,7 +96,7 @@
     </div>
 
     <!-- TABLA GRANDE ABAJO -->
-    <h3 class="subtitulo" style="margin-top: 26px;">Tasas de Impuesto Categoría</h3>
+    <h3 class="subtitulo subtitulo-impuesto">Tasas de Impuesto Categoría</h3>
     <table class="tabla-parametros">
         <thead>
             <tr>
@@ -113,10 +111,10 @@
         <tbody>
             <tr><td>0</td><td>Deducción fija</td><td>7 UIT</td><td>S/ 0.00</td><td>S/ 37,450.00</td><td></td></tr>
             <tr><td>1</td><td>0</td><td>5 UIT</td><td>S/ 0.00</td><td>S/ 26,750.01</td><td>8%</td></tr>
-            <tr><td>2</td><td>> 5 UIT</td><td>20 UIT</td><td>S/ 26,750.01</td><td>S/ 107,000.00</td><td>14%</td></tr>
-            <tr><td>3</td><td>> 20 UIT</td><td>35 UIT</td><td>S/ 107,000.01</td><td>S/ 187,250.00</td><td>17%</td></tr>
-            <tr><td>4</td><td>> 35 UIT</td><td>45 UIT</td><td>S/ 187,250.01</td><td>S/ 240,750.00</td><td>20%</td></tr>
-            <tr><td>5</td><td>> 45 UIT</td><td>En adelante</td><td>S/ 240,750.01</td><td>—</td><td>30%</td></tr>
+            <tr><td>2</td><td>&gt; 5 UIT</td><td>20 UIT</td><td>S/ 26,750.01</td><td>S/ 107,000.00</td><td>14%</td></tr>
+            <tr><td>3</td><td>&gt; 20 UIT</td><td>35 UIT</td><td>S/ 107,000.01</td><td>S/ 187,250.00</td><td>17%</td></tr>
+            <tr><td>4</td><td>&gt; 35 UIT</td><td>45 UIT</td><td>S/ 187,250.01</td><td>S/ 240,750.00</td><td>20%</td></tr>
+            <tr><td>5</td><td>&gt; 45 UIT</td><td>En adelante</td><td>S/ 240,750.01</td><td>—</td><td>30%</td></tr>
         </tbody>
     </table>
 

--- a/capa_presentacion/capa_presentacion.csproj
+++ b/capa_presentacion/capa_presentacion.csproj
@@ -526,6 +526,7 @@
     <Compile Include="Controllers\MenuController.cs" />
     <Compile Include="Controllers\NominaController.cs" />
     <Compile Include="Controllers\GenerarReporteController.cs" />
+    <Compile Include="Controllers\ParametrosController .cs" />
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
@@ -658,6 +659,7 @@
     <Content Include="Views\Nomina\_FormProcesarNomina.cshtml" />
     <Content Include="Views\Nomina\_ModalDetalleEmpleado.cshtml" />
     <Content Include="Views\Nomina\_ProcesandoNomina.cshtml" />
+    <Content Include="Views\Parametros\Index.cshtml" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="App_Data\" />


### PR DESCRIPTION
Se agregó la propiedad `tipoJornadaId` en `ContratoDTO` para incluir el tipo de jornada laboral. En `ContratosController`, se establecieron valores predeterminados de `1` para `TipoSalarioId` y `TipoJornadaId`, eliminando la necesidad de capturarlos desde el cliente.

Se deshabilitó la carga de catálogos de tipos de salarios y jornadas en `contratos.catalogs.js`. En `contratos.form.js`, se fijaron las horas semanales en `48` como valor predeterminado y de solo lectura, eliminando referencias a `TipoJornadaId`.

En `contratos.validation.js`, se eliminaron validaciones de tipo de jornada y horas semanales. Se simplificaron los formularios `_ModalEditarContrato.cshtml` y `_ModalNuevoContrato.cshtml`, eliminando campos redundantes como tipo de jornada, tarifa por hora y modo de pago.

Estos cambios reducen la complejidad en la lógica de negocio y la interfaz de usuario.