### PR TITLE
Resolver/issue

### DIFF
--- a/capa_presentacion/Controllers/ContratosController.cs
+++ b/capa_presentacion/Controllers/ContratosController.cs
@@ -150,7 +150,7 @@ namespace capa_presentacion.Controllers
             return Json(pensiones, JsonRequestBehavior.AllowGet);
         }
 
-       
+
         [HttpGet]
         public JsonResult ObtenerTiposJornadas()
         {
@@ -162,118 +162,119 @@ namespace capa_presentacion.Controllers
                 })
                 .ToList();
 
-        //    return Json(tipos, JsonRequestBehavior.AllowGet);
-        //}
+            return Json(tipos, JsonRequestBehavior.AllowGet);
+        }
 
         [HttpPost]
-        public JsonResult CrearContrato(ContratoDTO contrato)
-        {
-            try
+            public JsonResult CrearContrato(ContratoDTO contrato)
             {
-                contrato.TipoSalarioId = 1;
-                contrato.TipoJornadaId = 1;
-
-                var nuevoId = servicio.CrearContrato(contrato);
-
-                return Json(new
+                try
                 {
-                    exito = true,
-                    contratoId = nuevoId
-                });
+                    contrato.TipoSalarioId = 1;
+                    contrato.TipoJornadaId = 1;
+
+                    var nuevoId = servicio.CrearContrato(contrato);
+
+                    return Json(new
+                    {
+                        exito = true,
+                        contratoId = nuevoId
+                    });
+                }
+                catch (Exception ex)
+                {
+                    return Json(new
+                    {
+                        exito = false,
+                        mensaje = ex.Message
+                    });
+                }
             }
-            catch (Exception ex)
+
+            // ✅ Actualizar Contrato
+            [HttpPost]
+            public JsonResult ActualizarContrato(ContratoDTO contrato, string motivo)
             {
-                return Json(new
+                // ✔ Validaciones de entrada SIN lanzar Exception
+                if (contrato == null)
                 {
-                    exito = false,
-                    mensaje = ex.Message  
-                });
+                    return Json(new
+                    {
+                        exito = false,
+                        mensaje = "El contrato enviado es nulo."
+                    });
+                }
+
+                if (!contrato.ContratoId.HasValue || contrato.ContratoId.Value <= 0)
+                {
+                    return Json(new
+                    {
+                        exito = false,
+                        mensaje = "El contrato a actualizar no es válido."
+                    });
+                }
+
+                if (string.IsNullOrWhiteSpace(motivo))
+                {
+                    return Json(new
+                    {
+                        exito = false,
+                        mensaje = "Debes indicar el motivo de la actualización."
+                    });
+                }
+
+                try
+                {
+                    contrato.TipoSalarioId = 1;
+                    contrato.TipoJornadaId = 1;
+
+                    var usuario = User?.Identity != null && User.Identity.IsAuthenticated
+                        ? User.Identity.Name
+                        : Environment.UserName;
+
+                    servicio.ActualizarContrato(contrato.ContratoId.Value, usuario, motivo, contrato);
+
+                    return Json(new
+                    {
+                        exito = true,
+                        mensaje = "Contrato actualizado correctamente."
+                    });
+                }
+                catch (Exception ex)
+                {
+                    return Json(new
+                    {
+                        exito = false,
+                        mensaje = ex.Message
+                    });
+                }
             }
+
+
+            [HttpGet]
+            public JsonResult ResumenContratos()
+            {
+                try
+                {
+                    var resumen = servicio.ObtenerResumen();
+                    return Json(new
+                    {
+                        exito = true,
+                        data = resumen
+                    }, JsonRequestBehavior.AllowGet);
+                }
+                catch (Exception ex)
+                {
+                    return Json(new
+                    {
+                        exito = false,
+                        mensaje = ex.Message
+                    }, JsonRequestBehavior.AllowGet);
+                }
+            }
+
+
+
         }
-
-        // ✅ Actualizar Contrato
-        [HttpPost]
-        public JsonResult ActualizarContrato(ContratoDTO contrato, string motivo)
-        {
-            // ✔ Validaciones de entrada SIN lanzar Exception
-            if (contrato == null)
-            {
-                return Json(new
-                {
-                    exito = false,
-                    mensaje = "El contrato enviado es nulo."
-                });
-            }
-
-            if (!contrato.ContratoId.HasValue || contrato.ContratoId.Value <= 0)
-            {
-                return Json(new
-                {
-                    exito = false,
-                    mensaje = "El contrato a actualizar no es válido."
-                });
-            }
-
-            if (string.IsNullOrWhiteSpace(motivo))
-            {
-                return Json(new
-                {
-                    exito = false,
-                    mensaje = "Debes indicar el motivo de la actualización."
-                });
-            }
-
-            try
-            {
-                contrato.TipoSalarioId = 1;
-                contrato.TipoJornadaId = 1;
-
-                var usuario = User?.Identity != null && User.Identity.IsAuthenticated
-                    ? User.Identity.Name
-                    : Environment.UserName;
-
-                servicio.ActualizarContrato(contrato.ContratoId.Value, usuario, motivo, contrato);
-
-                return Json(new
-                {
-                    exito = true,
-                    mensaje = "Contrato actualizado correctamente."
-                });
-            }
-            catch (Exception ex)
-            {
-                return Json(new
-                {
-                    exito = false,
-                    mensaje = ex.Message  
-                });
-            }
-        }
-
-
-        [HttpGet]
-        public JsonResult ResumenContratos()
-        {
-            try
-            {
-                var resumen = servicio.ObtenerResumen();
-                return Json(new
-                {
-                    exito = true,
-                    data = resumen
-                }, JsonRequestBehavior.AllowGet);
-            }
-            catch (Exception ex)
-            {
-                return Json(new
-                {
-                    exito = false,
-                    mensaje = ex.Message
-                }, JsonRequestBehavior.AllowGet);
-            }
-        }
-
-
-
     }
-}
+

--- a/capa_presentacion/Scripts/contrato/contratos.catalogs.js
+++ b/capa_presentacion/Scripts/contrato/contratos.catalogs.js
@@ -68,7 +68,7 @@
             const $select = $(selector || '#nc_tipo_pension_id');
             $select.empty().append('<option value="">Seleccione</option>');
 
-            $.getJSON(window.ContratoConfig.URLS.obtenerPensiones)
+            $.getJSON(globalthis.ContratoConfig.URLS.obtenerPensiones)
                 .done(function (data) {
                     (data || []).forEach(function (p) {
                         const texto = p.entidad
@@ -156,8 +156,6 @@
             this.cargarAreas();
             this.cargarCargos();
             this.cargarPensiones();
-            //this.cargarTiposSalarios();
-            //this.cargarJornadas();
         },
 
         /**
@@ -167,8 +165,6 @@
             this.cargarAreas('#ec_area_id', item.AreaId);
             this.cargarPensiones('#ec_tipo_pension_id', item.TipoPensionId);
             this.cargarCargos('#ec_cargo_id', item.CargoId);
-            /*this.cargarTiposSalarios('#ec_tipo_salario_id', item.TipoSalarioId);*/
-            //this.cargarJornadas('#ec_tipo_jornada_id', item.TipoJornadaId);
         }
 
     };

--- a/capa_presentacion/Scripts/contrato/contratos.form.js
+++ b/capa_presentacion/Scripts/contrato/contratos.form.js
@@ -60,10 +60,10 @@
             $('#ec_observaciones').val(item.Observaciones || '');
 
             // Cargar catálogos con valores seleccionados
-            window.ContratoCatalogs.cargarTodosEdicion(item);
+            globalthis.ContratoCatalogs.cargarTodosEdicion(item);
 
             // Abrir modal
-            window.ContratoModal.open('modal-editar-contrato');
+            globalthis.ContratoModal.open('modal-editar-contrato');
         },
 
         /**
@@ -73,8 +73,6 @@
             $('#nc_cargo_id').val('');
             $('#nc_area_id').val('');
             $('#nc_tipo_pension_id').val('');
-            //$('#nc_tipo_salario_id').val('');
-            //$('#nc_tipo_jornada_id').val('');
             $('#nc_modo_pago').val('Depósito');
             $('#nc_modo_pago_id').val('1');
             $('#nc_fecha_inicio').val('');


### PR DESCRIPTION
This pull request primarily updates JavaScript code to use `globalthis` instead of `window` for accessing global variables and makes minor cleanups in both the backend controller and frontend scripts. It also removes commented-out code related to salary and workday types in several places.

**JavaScript global variable handling:**

* Replaced `window` with `globalthis` when accessing `ContratoConfig`, `ContratoCatalogs`, and `ContratoModal` in `contratos.catalogs.js` and `contratos.form.js` to improve compatibility and clarity. [[1]](diffhunk://#diff-b36461857a34d1d30c8edcd078757ba190555c3e426cc764774d455e555b9b4fL71-R71) [[2]](diffhunk://#diff-686da0ca74787ca444d877cbf174a6d29f40c9411524c1f06ead68b3171efec9L63-R66)

**Frontend code cleanup:**

* Removed commented-out lines related to loading salary and workday types in `contratos.catalogs.js` and `contratos.form.js` to reduce clutter and clarify which catalog loaders are in use. [[1]](diffhunk://#diff-b36461857a34d1d30c8edcd078757ba190555c3e426cc764774d455e555b9b4fL159-L160) [[2]](diffhunk://#diff-b36461857a34d1d30c8edcd078757ba190555c3e426cc764774d455e555b9b4fL170-L171) [[3]](diffhunk://#diff-686da0ca74787ca444d877cbf174a6d29f40c9411524c1f06ead68b3171efec9L76-L77)

**Backend controller fix:**

* Restored the return statement in `ObtenerTiposJornadas()` in `ContratosController.cs` to ensure the method returns the expected JSON result.